### PR TITLE
LR prefetch

### DIFF
--- a/src/backend/executor/execReplication.c
+++ b/src/backend/executor/execReplication.c
@@ -581,7 +581,7 @@ CheckAndReportConflict(ResultRelInfo *resultRelInfo, EState *estate,
  */
 void
 ExecSimpleRelationInsert(ResultRelInfo *resultRelInfo,
-						 EState *estate, TupleTableSlot *slot)
+						 EState *estate, TupleTableSlot *slot, bool prefetch)
 {
 	bool		skip_tuple = false;
 	Relation	rel = resultRelInfo->ri_RelationDesc;
@@ -625,7 +625,7 @@ ExecSimpleRelationInsert(ResultRelInfo *resultRelInfo,
 		if (resultRelInfo->ri_NumIndices > 0)
 			recheckIndexes = ExecInsertIndexTuples(resultRelInfo,
 												   slot, estate, false,
-												   conflictindexes ? true : false,
+												   conflictindexes || prefetch ? true : false,
 												   &conflict,
 												   conflictindexes, false);
 
@@ -644,7 +644,7 @@ ExecSimpleRelationInsert(ResultRelInfo *resultRelInfo,
 		 * be a frequent thing so we preferred to save the performance
 		 * overhead of extra scan before each insertion.
 		 */
-		if (conflict)
+		if (conflict && !prefetch)
 			CheckAndReportConflict(resultRelInfo, estate, CT_INSERT_EXISTS,
 								   recheckIndexes, NULL, slot);
 
@@ -671,7 +671,7 @@ ExecSimpleRelationInsert(ResultRelInfo *resultRelInfo,
 void
 ExecSimpleRelationUpdate(ResultRelInfo *resultRelInfo,
 						 EState *estate, EPQState *epqstate,
-						 TupleTableSlot *searchslot, TupleTableSlot *slot)
+						 TupleTableSlot *searchslot, TupleTableSlot *slot, bool prefetch)
 {
 	bool		skip_tuple = false;
 	Relation	rel = resultRelInfo->ri_RelationDesc;
@@ -722,7 +722,7 @@ ExecSimpleRelationUpdate(ResultRelInfo *resultRelInfo,
 		if (resultRelInfo->ri_NumIndices > 0 && (update_indexes != TU_None))
 			recheckIndexes = ExecInsertIndexTuples(resultRelInfo,
 												   slot, estate, true,
-												   conflictindexes ? true : false,
+												   conflictindexes || prefetch ? true : false,
 												   &conflict, conflictindexes,
 												   (update_indexes == TU_Summarizing));
 
@@ -731,7 +731,7 @@ ExecSimpleRelationUpdate(ResultRelInfo *resultRelInfo,
 		 * ExecSimpleRelationInsert to understand why this check is done at
 		 * this point.
 		 */
-		if (conflict)
+		if (conflict && !prefetch)
 			CheckAndReportConflict(resultRelInfo, estate, CT_UPDATE_EXISTS,
 								   recheckIndexes, searchslot, slot);
 

--- a/src/backend/executor/execReplication.c
+++ b/src/backend/executor/execReplication.c
@@ -131,7 +131,7 @@ build_replindex_scan_key(ScanKey skey, Relation rel, Relation idxrel,
  * invoking table_tuple_lock.
  */
 static bool
-should_refetch_tuple(TM_Result res, TM_FailureData *tmfd)
+should_refetch_tuple(TM_Result res, TM_FailureData *tmfd, LockTupleMode lockmode)
 {
 	bool		refetch = false;
 
@@ -141,22 +141,28 @@ should_refetch_tuple(TM_Result res, TM_FailureData *tmfd)
 			break;
 		case TM_Updated:
 			/* XXX: Improve handling here */
-			if (ItemPointerIndicatesMovedPartitions(&tmfd->ctid))
-				ereport(LOG,
-						(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
-						 errmsg("tuple to be locked was already moved to another partition due to concurrent update, retrying")));
-			else
-				ereport(LOG,
-						(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
-						 errmsg("concurrent update, retrying")));
-			refetch = true;
+			if (lockmode != LockTupleTryExclusive)
+			{
+				if (ItemPointerIndicatesMovedPartitions(&tmfd->ctid))
+					ereport(LOG,
+							(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+							 errmsg("tuple to be locked was already moved to another partition due to concurrent update, retrying")));
+				else
+					ereport(LOG,
+							(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+							 errmsg("concurrent update, retrying")));
+				refetch = true;
+			}
 			break;
 		case TM_Deleted:
-			/* XXX: Improve handling here */
-			ereport(LOG,
-					(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
-					 errmsg("concurrent delete, retrying")));
-			refetch = true;
+			if (lockmode != LockTupleTryExclusive)
+			{
+				/* XXX: Improve handling here */
+				ereport(LOG,
+						(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+						 errmsg("concurrent delete, retrying")));
+				refetch = true;
+			}
 			break;
 		case TM_Invisible:
 			elog(ERROR, "attempted to lock invisible tuple");
@@ -236,8 +242,16 @@ retry:
 		 */
 		if (TransactionIdIsValid(xwait))
 		{
-			XactLockTableWait(xwait, NULL, NULL, XLTW_None);
-			goto retry;
+			if (lockmode == LockTupleTryExclusive)
+			{
+				found = false;
+				break;
+			}
+			else if (lockmode != LockTupleNoLock)
+			{
+				XactLockTableWait(xwait, NULL, NULL, XLTW_None);
+				goto retry;
+			}
 		}
 
 		/* Found our tuple and it's not locked */
@@ -246,7 +260,7 @@ retry:
 	}
 
 	/* Found tuple, try to lock it in the lockmode. */
-	if (found)
+	if (found && lockmode != LockTupleNoLock)
 	{
 		TM_FailureData tmfd;
 		TM_Result	res;
@@ -256,14 +270,14 @@ retry:
 		res = table_tuple_lock(rel, &(outslot->tts_tid), GetActiveSnapshot(),
 							   outslot,
 							   GetCurrentCommandId(false),
-							   lockmode,
+							   lockmode == LockTupleTryExclusive ? LockTupleExclusive : lockmode,
 							   LockWaitBlock,
 							   0 /* don't follow updates */ ,
 							   &tmfd);
 
 		PopActiveSnapshot();
 
-		if (should_refetch_tuple(res, &tmfd))
+		if (should_refetch_tuple(res, &tmfd, lockmode))
 			goto retry;
 	}
 
@@ -395,16 +409,23 @@ retry:
 		 */
 		if (TransactionIdIsValid(xwait))
 		{
-			XactLockTableWait(xwait, NULL, NULL, XLTW_None);
-			goto retry;
+			if (lockmode == LockTupleTryExclusive)
+			{
+				found = false;
+				break;
+			}
+			else if (lockmode != LockTupleNoLock)
+			{
+				XactLockTableWait(xwait, NULL, NULL, XLTW_None);
+				goto retry;
+			}
 		}
-
 		/* Found our tuple and it's not locked */
 		break;
 	}
 
 	/* Found tuple, try to lock it in the lockmode. */
-	if (found)
+	if (found && lockmode != LockTupleNoLock)
 	{
 		TM_FailureData tmfd;
 		TM_Result	res;
@@ -414,14 +435,14 @@ retry:
 		res = table_tuple_lock(rel, &(outslot->tts_tid), GetActiveSnapshot(),
 							   outslot,
 							   GetCurrentCommandId(false),
-							   lockmode,
+							   lockmode == LockTupleTryExclusive ? LockTupleExclusive : lockmode,
 							   LockWaitBlock,
 							   0 /* don't follow updates */ ,
 							   &tmfd);
 
 		PopActiveSnapshot();
 
-		if (should_refetch_tuple(res, &tmfd))
+		if (should_refetch_tuple(res, &tmfd, lockmode))
 			goto retry;
 	}
 
@@ -508,7 +529,7 @@ retry:
 
 	PopActiveSnapshot();
 
-	if (should_refetch_tuple(res, &tmfd))
+	if (should_refetch_tuple(res, &tmfd, LockTupleShare))
 		goto retry;
 
 	return true;

--- a/src/backend/executor/execReplication.c
+++ b/src/backend/executor/execReplication.c
@@ -131,7 +131,7 @@ build_replindex_scan_key(ScanKey skey, Relation rel, Relation idxrel,
  * invoking table_tuple_lock.
  */
 static bool
-should_refetch_tuple(TM_Result res, TM_FailureData *tmfd, LockTupleMode lockmode)
+should_refetch_tuple(TM_Result res, TM_FailureData *tmfd)
 {
 	bool		refetch = false;
 
@@ -141,28 +141,22 @@ should_refetch_tuple(TM_Result res, TM_FailureData *tmfd, LockTupleMode lockmode
 			break;
 		case TM_Updated:
 			/* XXX: Improve handling here */
-			if (lockmode != LockTupleTryExclusive)
-			{
-				if (ItemPointerIndicatesMovedPartitions(&tmfd->ctid))
-					ereport(LOG,
-							(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
-							 errmsg("tuple to be locked was already moved to another partition due to concurrent update, retrying")));
-				else
-					ereport(LOG,
-							(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
-							 errmsg("concurrent update, retrying")));
-				refetch = true;
-			}
-			break;
-		case TM_Deleted:
-			if (lockmode != LockTupleTryExclusive)
-			{
-				/* XXX: Improve handling here */
+			if (ItemPointerIndicatesMovedPartitions(&tmfd->ctid))
 				ereport(LOG,
 						(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
-						 errmsg("concurrent delete, retrying")));
-				refetch = true;
-			}
+						 errmsg("tuple to be locked was already moved to another partition due to concurrent update, retrying")));
+			else
+				ereport(LOG,
+						(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+						 errmsg("concurrent update, retrying")));
+			refetch = true;
+			break;
+		case TM_Deleted:
+			/* XXX: Improve handling here */
+			ereport(LOG,
+					(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+					 errmsg("concurrent delete, retrying")));
+			refetch = true;
 			break;
 		case TM_Invisible:
 			elog(ERROR, "attempted to lock invisible tuple");
@@ -242,16 +236,8 @@ retry:
 		 */
 		if (TransactionIdIsValid(xwait))
 		{
-			if (lockmode == LockTupleTryExclusive)
-			{
-				found = false;
-				break;
-			}
-			else if (lockmode != LockTupleNoLock)
-			{
-				XactLockTableWait(xwait, NULL, NULL, XLTW_None);
-				goto retry;
-			}
+			XactLockTableWait(xwait, NULL, NULL, XLTW_None);
+			goto retry;
 		}
 
 		/* Found our tuple and it's not locked */
@@ -260,7 +246,7 @@ retry:
 	}
 
 	/* Found tuple, try to lock it in the lockmode. */
-	if (found && lockmode != LockTupleNoLock)
+	if (found)
 	{
 		TM_FailureData tmfd;
 		TM_Result	res;
@@ -270,14 +256,14 @@ retry:
 		res = table_tuple_lock(rel, &(outslot->tts_tid), GetActiveSnapshot(),
 							   outslot,
 							   GetCurrentCommandId(false),
-							   lockmode == LockTupleTryExclusive ? LockTupleExclusive : lockmode,
+							   lockmode,
 							   LockWaitBlock,
 							   0 /* don't follow updates */ ,
 							   &tmfd);
 
 		PopActiveSnapshot();
 
-		if (should_refetch_tuple(res, &tmfd, lockmode))
+		if (should_refetch_tuple(res, &tmfd))
 			goto retry;
 	}
 
@@ -285,6 +271,47 @@ retry:
 
 	/* Don't release lock until commit. */
 	index_close(idxrel, NoLock);
+
+	return found;
+}
+
+/*
+ * Search the relation 'rel' for tuple using the index.
+ * Returns true if tuple is found.
+ */
+bool
+RelationPrefetchIndex(Relation rel, Oid idxoid, TupleTableSlot *searchslot,
+					  TupleTableSlot *outslot)
+{
+	ScanKeyData skey[INDEX_MAX_KEYS];
+	int			skey_attoff;
+	IndexScanDesc scan;
+	SnapshotData snap;
+	Relation	idxrel;
+	bool		found;
+
+	/* Do not do prefetch when there is no index */
+	if (!OidIsValid(idxoid))
+		return false;
+
+	/* Open the index. */
+	idxrel = index_open(idxoid, AccessShareLock);
+
+	InitDirtySnapshot(snap);
+
+	/* Build scan key. */
+	skey_attoff = build_replindex_scan_key(skey, rel, idxrel, searchslot);
+
+	/* Start an index scan. */
+	scan = index_beginscan(rel, idxrel, &snap, NULL, skey_attoff, 0);
+	index_rescan(scan, skey, skey_attoff, NULL, 0);
+
+	/* Try to find the tuple */
+	found = index_getnext_slot(scan, ForwardScanDirection, outslot);
+
+	/* Cleanup */
+	index_endscan(scan);
+	index_close(idxrel, AccessShareLock);
 
 	return found;
 }
@@ -409,23 +436,16 @@ retry:
 		 */
 		if (TransactionIdIsValid(xwait))
 		{
-			if (lockmode == LockTupleTryExclusive)
-			{
-				found = false;
-				break;
-			}
-			else if (lockmode != LockTupleNoLock)
-			{
-				XactLockTableWait(xwait, NULL, NULL, XLTW_None);
-				goto retry;
-			}
+			XactLockTableWait(xwait, NULL, NULL, XLTW_None);
+			goto retry;
 		}
+
 		/* Found our tuple and it's not locked */
 		break;
 	}
 
 	/* Found tuple, try to lock it in the lockmode. */
-	if (found && lockmode != LockTupleNoLock)
+	if (found)
 	{
 		TM_FailureData tmfd;
 		TM_Result	res;
@@ -435,14 +455,14 @@ retry:
 		res = table_tuple_lock(rel, &(outslot->tts_tid), GetActiveSnapshot(),
 							   outslot,
 							   GetCurrentCommandId(false),
-							   lockmode == LockTupleTryExclusive ? LockTupleExclusive : lockmode,
+							   lockmode,
 							   LockWaitBlock,
 							   0 /* don't follow updates */ ,
 							   &tmfd);
 
 		PopActiveSnapshot();
 
-		if (should_refetch_tuple(res, &tmfd, lockmode))
+		if (should_refetch_tuple(res, &tmfd))
 			goto retry;
 	}
 
@@ -529,7 +549,7 @@ retry:
 
 	PopActiveSnapshot();
 
-	if (should_refetch_tuple(res, &tmfd, LockTupleShare))
+	if (should_refetch_tuple(res, &tmfd))
 		goto retry;
 
 	return true;
@@ -581,7 +601,7 @@ CheckAndReportConflict(ResultRelInfo *resultRelInfo, EState *estate,
  */
 void
 ExecSimpleRelationInsert(ResultRelInfo *resultRelInfo,
-						 EState *estate, TupleTableSlot *slot, bool prefetch)
+						 EState *estate, TupleTableSlot *slot)
 {
 	bool		skip_tuple = false;
 	Relation	rel = resultRelInfo->ri_RelationDesc;
@@ -625,7 +645,7 @@ ExecSimpleRelationInsert(ResultRelInfo *resultRelInfo,
 		if (resultRelInfo->ri_NumIndices > 0)
 			recheckIndexes = ExecInsertIndexTuples(resultRelInfo,
 												   slot, estate, false,
-												   conflictindexes || prefetch ? true : false,
+												   conflictindexes ? true : false,
 												   &conflict,
 												   conflictindexes, false);
 
@@ -644,7 +664,7 @@ ExecSimpleRelationInsert(ResultRelInfo *resultRelInfo,
 		 * be a frequent thing so we preferred to save the performance
 		 * overhead of extra scan before each insertion.
 		 */
-		if (conflict && !prefetch)
+		if (conflict)
 			CheckAndReportConflict(resultRelInfo, estate, CT_INSERT_EXISTS,
 								   recheckIndexes, NULL, slot);
 
@@ -671,7 +691,7 @@ ExecSimpleRelationInsert(ResultRelInfo *resultRelInfo,
 void
 ExecSimpleRelationUpdate(ResultRelInfo *resultRelInfo,
 						 EState *estate, EPQState *epqstate,
-						 TupleTableSlot *searchslot, TupleTableSlot *slot, bool prefetch)
+						 TupleTableSlot *searchslot, TupleTableSlot *slot)
 {
 	bool		skip_tuple = false;
 	Relation	rel = resultRelInfo->ri_RelationDesc;
@@ -722,7 +742,7 @@ ExecSimpleRelationUpdate(ResultRelInfo *resultRelInfo,
 		if (resultRelInfo->ri_NumIndices > 0 && (update_indexes != TU_None))
 			recheckIndexes = ExecInsertIndexTuples(resultRelInfo,
 												   slot, estate, true,
-												   conflictindexes || prefetch ? true : false,
+												   conflictindexes ? true : false,
 												   &conflict, conflictindexes,
 												   (update_indexes == TU_Summarizing));
 
@@ -731,7 +751,7 @@ ExecSimpleRelationUpdate(ResultRelInfo *resultRelInfo,
 		 * ExecSimpleRelationInsert to understand why this check is done at
 		 * this point.
 		 */
-		if (conflict && !prefetch)
+		if (conflict)
 			CheckAndReportConflict(resultRelInfo, estate, CT_UPDATE_EXISTS,
 								   recheckIndexes, searchslot, slot);
 

--- a/src/backend/replication/logical/applyparallelworker.c
+++ b/src/backend/replication/logical/applyparallelworker.c
@@ -741,9 +741,9 @@ pa_apply_dispatch(StringInfo s)
 		}
 		PG_CATCH();
 		{
-			elog(DEBUG1, "Failed to prefetch LR operation");
-
 			HOLD_INTERRUPTS();
+
+			elog(DEBUG1, "Failed to prefetch LR operation");
 
 			/* TODO: should we somehow dump the error or just silently ignore it? */
 			/* EmitErrorReport(); */
@@ -754,8 +754,11 @@ pa_apply_dispatch(StringInfo s)
 			lr_prefetch_errors += 1;
 		}
 		PG_END_TRY();
-		/* We need to abort transaction to undo insert */
-		AbortCurrentTransaction();
+		if (!prefetch_replica_identity_only)
+		{
+			/* We need to abort transaction to undo insert */
+			AbortCurrentTransaction();
+		}
 	}
 	else
 	{
@@ -992,6 +995,11 @@ ParallelApplyWorkerMain(Datum main_arg)
 		replorigin_session_setup(originid, MyLogicalRepWorker->leader_pid);
 		replorigin_session_origin = originid;
 		CommitTransactionCommand();
+	}
+	else
+	{
+		/* Do not write WAL for prefetch */
+		wal_level = WAL_LEVEL_MINIMAL;
 	}
 	/*
 	 * Setup callback for syscache so that we know when something changes in

--- a/src/backend/replication/logical/applyparallelworker.c
+++ b/src/backend/replication/logical/applyparallelworker.c
@@ -400,7 +400,7 @@ pa_setup_dsm(ParallelApplyWorkerInfo *winfo)
  * Try to get a parallel apply worker from the pool. If none is available then
  * start a new one.
  */
-static ParallelApplyWorkerInfo *
+ParallelApplyWorkerInfo *
 pa_launch_parallel_worker(void)
 {
 	MemoryContext oldcontext;

--- a/src/backend/replication/logical/applyparallelworker.c
+++ b/src/backend/replication/logical/applyparallelworker.c
@@ -729,6 +729,40 @@ ProcessParallelApplyInterrupts(void)
 	}
 }
 
+
+static void
+pa_apply_dispatch(StringInfo s)
+{
+	if (MyParallelShared->do_prefetch)
+	{
+		PG_TRY();
+		{
+			apply_dispatch(s);
+		}
+		PG_CATCH();
+		{
+			elog(DEBUG1, "Failed to prefetch LR operation");
+
+			HOLD_INTERRUPTS();
+
+			/* TODO: should we somehow dump the error or just silently ignore it? */
+			/* EmitErrorReport(); */
+			FlushErrorState();
+
+			RESUME_INTERRUPTS();
+
+			lr_prefetch_errors += 1;
+		}
+		PG_END_TRY();
+		/* We need to abort transaction to undo insert */
+		AbortCurrentTransaction();
+	}
+	else
+	{
+		apply_dispatch(s);
+	}
+}
+
 /* Parallel apply worker main loop. */
 static void
 LogicalParallelApplyLoop(shm_mq_handle *mqh)
@@ -794,7 +828,7 @@ LogicalParallelApplyLoop(shm_mq_handle *mqh)
 			 */
 			s.cursor += SIZE_STATS_MESSAGE;
 
-			apply_dispatch(&s);
+			pa_apply_dispatch(&s);
 		}
 		else if (shmq_res == SHM_MQ_WOULD_BLOCK)
 		{
@@ -943,20 +977,22 @@ ParallelApplyWorkerMain(Datum main_arg)
 
 	InitializingApplyWorker = false;
 
-	/* Setup replication origin tracking. */
-	StartTransactionCommand();
-	ReplicationOriginNameForLogicalRep(MySubscription->oid, InvalidOid,
+	if (!MyParallelShared->do_prefetch)
+	{
+		/* Setup replication origin tracking. */
+		StartTransactionCommand();
+		ReplicationOriginNameForLogicalRep(MySubscription->oid, InvalidOid,
 									   originname, sizeof(originname));
-	originid = replorigin_by_name(originname, false);
+		originid = replorigin_by_name(originname, false);
 
-	/*
-	 * The parallel apply worker doesn't need to monopolize this replication
-	 * origin which was already acquired by its leader process.
-	 */
-	replorigin_session_setup(originid, MyLogicalRepWorker->leader_pid);
-	replorigin_session_origin = originid;
-	CommitTransactionCommand();
-
+		/*
+		 * The parallel apply worker doesn't need to monopolize this replication
+		 * origin which was already acquired by its leader process.
+		 */
+		replorigin_session_setup(originid, MyLogicalRepWorker->leader_pid);
+		replorigin_session_origin = originid;
+		CommitTransactionCommand();
+	}
 	/*
 	 * Setup callback for syscache so that we know when something changes in
 	 * the subscription relation state.
@@ -1149,8 +1185,11 @@ pa_send_data(ParallelApplyWorkerInfo *winfo, Size nbytes, const void *data)
 	shm_mq_result result;
 	TimestampTz startTime = 0;
 
-	Assert(!IsTransactionState());
-	Assert(!winfo->serialize_changes);
+	if (!winfo->shared->do_prefetch)
+	{
+		Assert(!IsTransactionState());
+		Assert(!winfo->serialize_changes);
+	}
 
 	/*
 	 * We don't try to send data to parallel worker for 'immediate' mode. This

--- a/src/backend/replication/logical/applyparallelworker.c
+++ b/src/backend/replication/logical/applyparallelworker.c
@@ -397,10 +397,61 @@ pa_setup_dsm(ParallelApplyWorkerInfo *winfo)
 }
 
 /*
+ * Try to get a parallel prefetch worker.
+ */
+ParallelApplyWorkerInfo *
+pa_launch_prefetch_worker(void)
+{
+	MemoryContext oldcontext;
+	bool		launched;
+	ParallelApplyWorkerInfo *winfo;
+
+	/*
+	 * Start a new parallel prefetch worker.
+	 *
+	 * The worker info can be used for the lifetime of the worker process, so
+	 * create it in a permanent context.
+	 */
+	oldcontext = MemoryContextSwitchTo(ApplyContext);
+
+	winfo = (ParallelApplyWorkerInfo *) palloc0(sizeof(ParallelApplyWorkerInfo));
+
+	/* Setup shared memory. */
+	if (!pa_setup_dsm(winfo))
+	{
+		MemoryContextSwitchTo(oldcontext);
+		pfree(winfo);
+		return NULL;
+	}
+
+	launched = logicalrep_worker_launch(WORKERTYPE_PARALLEL_PREFETCH,
+										MyLogicalRepWorker->dbid,
+										MySubscription->oid,
+										MySubscription->name,
+										MyLogicalRepWorker->userid,
+										InvalidOid,
+										dsm_segment_handle(winfo->dsm_seg));
+
+	if (launched)
+	{
+		winfo->do_prefetch = true;
+	}
+	else
+	{
+		pa_free_worker_info(winfo);
+		winfo = NULL;
+	}
+
+	MemoryContextSwitchTo(oldcontext);
+
+	return winfo;
+}
+
+/*
  * Try to get a parallel apply worker from the pool. If none is available then
  * start a new one.
  */
-ParallelApplyWorkerInfo *
+static ParallelApplyWorkerInfo *
 pa_launch_parallel_worker(void)
 {
 	MemoryContext oldcontext;
@@ -729,43 +780,6 @@ ProcessParallelApplyInterrupts(void)
 	}
 }
 
-
-static void
-pa_apply_dispatch(StringInfo s)
-{
-	if (MyParallelShared->do_prefetch)
-	{
-		PG_TRY();
-		{
-			apply_dispatch(s);
-		}
-		PG_CATCH();
-		{
-			HOLD_INTERRUPTS();
-
-			elog(DEBUG1, "Failed to prefetch LR operation");
-
-			/* TODO: should we somehow dump the error or just silently ignore it? */
-			/* EmitErrorReport(); */
-			FlushErrorState();
-
-			RESUME_INTERRUPTS();
-
-			lr_prefetch_errors += 1;
-		}
-		PG_END_TRY();
-		if (!prefetch_replica_identity_only)
-		{
-			/* We need to abort transaction to undo insert */
-			AbortCurrentTransaction();
-		}
-	}
-	else
-	{
-		apply_dispatch(s);
-	}
-}
-
 /* Parallel apply worker main loop. */
 static void
 LogicalParallelApplyLoop(shm_mq_handle *mqh)
@@ -831,7 +845,7 @@ LogicalParallelApplyLoop(shm_mq_handle *mqh)
 			 */
 			s.cursor += SIZE_STATS_MESSAGE;
 
-			pa_apply_dispatch(&s);
+			apply_dispatch(&s);
 		}
 		else if (shmq_res == SHM_MQ_WOULD_BLOCK)
 		{
@@ -980,7 +994,7 @@ ParallelApplyWorkerMain(Datum main_arg)
 
 	InitializingApplyWorker = false;
 
-	if (!MyParallelShared->do_prefetch)
+	if (am_parallel_apply_worker())
 	{
 		/* Setup replication origin tracking. */
 		StartTransactionCommand();
@@ -995,11 +1009,6 @@ ParallelApplyWorkerMain(Datum main_arg)
 		replorigin_session_setup(originid, MyLogicalRepWorker->leader_pid);
 		replorigin_session_origin = originid;
 		CommitTransactionCommand();
-	}
-	else
-	{
-		/* Do not write WAL for prefetch */
-		wal_level = WAL_LEVEL_MINIMAL;
 	}
 	/*
 	 * Setup callback for syscache so that we know when something changes in
@@ -1193,7 +1202,7 @@ pa_send_data(ParallelApplyWorkerInfo *winfo, Size nbytes, const void *data)
 	shm_mq_result result;
 	TimestampTz startTime = 0;
 
-	if (!winfo->shared->do_prefetch)
+	if (!winfo->do_prefetch)
 	{
 		Assert(!IsTransactionState());
 		Assert(!winfo->serialize_changes);
@@ -1565,6 +1574,9 @@ static PartialFileSetState
 pa_get_fileset_state(void)
 {
 	PartialFileSetState fileset_state;
+
+	if (am_parallel_prefetch_worker())
+		return FS_EMPTY;
 
 	Assert(am_parallel_apply_worker());
 

--- a/src/backend/replication/logical/launcher.c
+++ b/src/backend/replication/logical/launcher.c
@@ -258,7 +258,7 @@ logicalrep_worker_find(Oid subid, Oid relid, bool only_running)
 		LogicalRepWorker *w = &LogicalRepCtx->workers[i];
 
 		/* Skip parallel apply workers. */
-		if (isParallelApplyWorker(w))
+		if (isParallelApplyWorker(w) || isParallelPrefetchWorker(w))
 			continue;
 
 		if (w->in_use && w->subid == subid && w->relid == relid &&
@@ -323,6 +323,7 @@ logicalrep_worker_launch(LogicalRepWorkerType wtype,
 	TimestampTz now;
 	bool		is_tablesync_worker = (wtype == WORKERTYPE_TABLESYNC);
 	bool		is_parallel_apply_worker = (wtype == WORKERTYPE_PARALLEL_APPLY);
+	bool		is_parallel_prefetch_worker = (wtype == WORKERTYPE_PARALLEL_PREFETCH);
 
 	/*----------
 	 * Sanity checks:
@@ -332,7 +333,7 @@ logicalrep_worker_launch(LogicalRepWorkerType wtype,
 	 */
 	Assert(wtype != WORKERTYPE_UNKNOWN);
 	Assert(is_tablesync_worker == OidIsValid(relid));
-	Assert(is_parallel_apply_worker == (subworker_dsm != DSM_HANDLE_INVALID));
+	Assert((is_parallel_apply_worker|is_parallel_prefetch_worker) == (subworker_dsm != DSM_HANDLE_INVALID));
 
 	ereport(DEBUG1,
 			(errmsg_internal("starting logical replication worker for subscription \"%s\"",
@@ -453,8 +454,8 @@ retry:
 	worker->relstate = SUBREL_STATE_UNKNOWN;
 	worker->relstate_lsn = InvalidXLogRecPtr;
 	worker->stream_fileset = NULL;
-	worker->leader_pid = is_parallel_apply_worker ? MyProcPid : InvalidPid;
-	worker->parallel_apply = is_parallel_apply_worker;
+	worker->leader_pid = (is_parallel_apply_worker|is_parallel_prefetch_worker) ? MyProcPid : InvalidPid;
+	worker->parallel_apply = is_parallel_apply_worker|is_parallel_prefetch_worker;
 	worker->last_lsn = InvalidXLogRecPtr;
 	TIMESTAMP_NOBEGIN(worker->last_send_time);
 	TIMESTAMP_NOBEGIN(worker->last_recv_time);
@@ -487,6 +488,16 @@ retry:
 			snprintf(bgw.bgw_function_name, BGW_MAXLEN, "ParallelApplyWorkerMain");
 			snprintf(bgw.bgw_name, BGW_MAXLEN,
 					 "logical replication parallel apply worker for subscription %u",
+					 subid);
+			snprintf(bgw.bgw_type, BGW_MAXLEN, "logical replication parallel worker");
+
+			memcpy(bgw.bgw_extra, &subworker_dsm, sizeof(dsm_handle));
+			break;
+
+		case WORKERTYPE_PARALLEL_PREFETCH:
+			snprintf(bgw.bgw_function_name, BGW_MAXLEN, "ParallelApplyWorkerMain");
+			snprintf(bgw.bgw_name, BGW_MAXLEN,
+					 "logical replication parallel prefetch worker for subscription %u",
 					 subid);
 			snprintf(bgw.bgw_type, BGW_MAXLEN, "logical replication parallel worker");
 
@@ -627,7 +638,7 @@ logicalrep_worker_stop(Oid subid, Oid relid)
 
 	if (worker)
 	{
-		Assert(!isParallelApplyWorker(worker));
+		Assert(!isParallelApplyWorker(worker) && !isParallelPrefetchWorker(worker));
 		logicalrep_worker_stop_internal(worker, SIGTERM);
 	}
 
@@ -775,7 +786,7 @@ logicalrep_worker_detach(void)
 		{
 			LogicalRepWorker *w = (LogicalRepWorker *) lfirst(lc);
 
-			if (isParallelApplyWorker(w))
+			if (isParallelApplyWorker(w) || isParallelPrefetchWorker(w))
 				logicalrep_worker_stop_internal(w, SIGTERM);
 		}
 
@@ -1369,6 +1380,9 @@ pg_stat_get_subscription(PG_FUNCTION_ARGS)
 				break;
 			case WORKERTYPE_PARALLEL_APPLY:
 				values[9] = CStringGetTextDatum("parallel apply");
+				break;
+			case WORKERTYPE_PARALLEL_PREFETCH:
+				values[9] = CStringGetTextDatum("parallel prefetch");
 				break;
 			case WORKERTYPE_TABLESYNC:
 				values[9] = CStringGetTextDatum("table synchronization");

--- a/src/backend/replication/logical/launcher.c
+++ b/src/backend/replication/logical/launcher.c
@@ -50,6 +50,7 @@
 int			max_logical_replication_workers = 4;
 int			max_sync_workers_per_subscription = 2;
 int			max_parallel_apply_workers_per_subscription = 2;
+int			max_parallel_prefetch_workers_per_subscription = 2;
 
 LogicalRepWorker *MyLogicalRepWorker = NULL;
 

--- a/src/backend/replication/logical/tablesync.c
+++ b/src/backend/replication/logical/tablesync.c
@@ -681,6 +681,9 @@ process_syncing_tables(XLogRecPtr current_lsn)
 			 */
 			break;
 
+		case WORKERTYPE_PARALLEL_PREFETCH:
+			break;
+
 		case WORKERTYPE_TABLESYNC:
 			process_syncing_tables_for_sync(current_lsn);
 			break;

--- a/src/backend/replication/logical/worker.c
+++ b/src/backend/replication/logical/worker.c
@@ -311,6 +311,18 @@ static uint32 parallel_stream_nchanges = 0;
 /* Are we initializing an apply worker? */
 bool		InitializingApplyWorker = false;
 
+#define INIT_PREFETCH_BUF_SIZE (64*1024)
+static ParallelApplyWorkerInfo* prefetch_worker[MAX_LR_PREFETCH_WORKERS];
+static int prefetch_worker_rr = 0;
+static int n_prefetch_workers;
+
+bool prefetch_replica_identity_only = true;
+
+size_t lr_prefetch_hits;
+size_t lr_prefetch_misses;
+size_t lr_prefetch_errors;
+size_t lr_prefetch_inserts;
+
 /*
  * We enable skipping all data modification changes (INSERT, UPDATE, etc.) for
  * the subscription if the remote transaction's finish LSN matches the subskiplsn.
@@ -328,6 +340,11 @@ bool		InitializingApplyWorker = false;
  */
 static XLogRecPtr skip_xact_finish_lsn = InvalidXLogRecPtr;
 #define is_skipping_changes() (unlikely(!XLogRecPtrIsInvalid(skip_xact_finish_lsn)))
+
+/*
+ * If operation is performed by parallel prefetch worker
+ */
+#define is_prefetching()	(am_parallel_apply_worker() && MyParallelShared->do_prefetch)
 
 /* BufFile handle of the current streaming file */
 static BufFile *stream_fd = NULL;
@@ -555,6 +572,11 @@ handle_streamed_transaction(LogicalRepMsgType action, StringInfo s)
 	ParallelApplyWorkerInfo *winfo;
 	TransApplyAction apply_action;
 	StringInfoData original_msg;
+
+	if (is_prefetching())
+	{
+		return false;
+	}
 
 	apply_action = get_transaction_apply_action(stream_xid, &winfo);
 
@@ -2487,13 +2509,35 @@ apply_handle_insert_internal(ApplyExecutionData *edata,
 		   !relinfo->ri_RelationDesc->rd_rel->relhasindex ||
 		   RelationGetIndexList(relinfo->ri_RelationDesc) == NIL);
 
-	/* Caller will not have done this bit. */
-	Assert(relinfo->ri_onConflictArbiterIndexes == NIL);
-	InitConflictIndexes(relinfo);
+	if (is_prefetching() && prefetch_replica_identity_only)
+	{
+		TupleTableSlot *localslot = NULL;
+		LogicalRepRelMapEntry *relmapentry = edata->targetRel;
+		Relation		localrel = relinfo->ri_RelationDesc;
+		EPQState		epqstate;
 
-	/* Do the insert. */
-	TargetPrivilegesCheck(relinfo->ri_RelationDesc, ACL_INSERT);
-	ExecSimpleRelationInsert(relinfo, estate, remoteslot);
+		EvalPlanQualInit(&epqstate, estate, NULL, NIL, -1, NIL);
+		ExecOpenIndices(relinfo, false);
+
+		(void)FindReplTupleInLocalRel(edata, localrel,
+									  &relmapentry->remoterel,
+									  relmapentry->localindexoid,
+									  remoteslot, &localslot);
+	}
+	else
+	{
+		/* Caller will not have done this bit. */
+		Assert(relinfo->ri_onConflictArbiterIndexes == NIL);
+		InitConflictIndexes(relinfo);
+
+		/* Do the insert. */
+		TargetPrivilegesCheck(relinfo->ri_RelationDesc, ACL_INSERT);
+		ExecSimpleRelationInsert(relinfo, estate, remoteslot);
+	}
+	if (is_prefetching())
+	{
+		lr_prefetch_inserts += 1;
+	}
 }
 
 /*
@@ -2682,6 +2726,16 @@ apply_handle_update_internal(ApplyExecutionData *edata,
 									localindexoid,
 									remoteslot, &localslot);
 
+	if (is_prefetching())
+	{
+		if (found)
+			lr_prefetch_hits += 1;
+		else
+			lr_prefetch_misses += 1;
+		if (prefetch_replica_identity_only)
+			goto Cleanup;
+	}
+
 	/*
 	 * Tuple found.
 	 *
@@ -2739,7 +2793,7 @@ apply_handle_update_internal(ApplyExecutionData *edata,
 							remoteslot, newslot, list_make1(&conflicttuple));
 	}
 
-	/* Cleanup. */
+  Cleanup:
 	ExecCloseIndices(relinfo);
 	EvalPlanQualEnd(&epqstate);
 }
@@ -2867,6 +2921,15 @@ apply_handle_delete_internal(ApplyExecutionData *edata,
 	found = FindReplTupleInLocalRel(edata, localrel, remoterel, localindexoid,
 									remoteslot, &localslot);
 
+	if (is_prefetching())
+	{
+		if (found)
+			lr_prefetch_hits += 1;
+		else
+			lr_prefetch_misses += 1;
+		goto Cleanup;
+	}
+
 	/* If found delete it. */
 	if (found)
 	{
@@ -2900,7 +2963,7 @@ apply_handle_delete_internal(ApplyExecutionData *edata,
 							remoteslot, NULL, list_make1(&conflicttuple));
 	}
 
-	/* Cleanup. */
+  Cleanup:
 	EvalPlanQualEnd(&epqstate);
 }
 
@@ -2920,6 +2983,8 @@ FindReplTupleInLocalRel(ApplyExecutionData *edata, Relation localrel,
 {
 	EState	   *estate = edata->estate;
 	bool		found;
+
+	LockTupleMode lockmode = is_prefetching() ? prefetch_replica_identity_only ? LockTupleNoLock : LockTupleTryExclusive : LockTupleExclusive;
 
 	/*
 	 * Regardless of the top-level operation, we're performing a read here, so
@@ -2946,11 +3011,11 @@ FindReplTupleInLocalRel(ApplyExecutionData *edata, Relation localrel,
 #endif
 
 		found = RelationFindReplTupleByIndex(localrel, localidxoid,
-											 LockTupleExclusive,
+											 lockmode,
 											 remoteslot, *localslot);
 	}
 	else
-		found = RelationFindReplTupleSeq(localrel, LockTupleExclusive,
+		found = RelationFindReplTupleSeq(localrel, lockmode,
 										 remoteslot, *localslot);
 
 	return found;
@@ -3076,6 +3141,9 @@ apply_handle_tuple_routing(ApplyExecutionData *edata,
 				{
 					TupleTableSlot *newslot = localslot;
 
+					if (is_prefetching())
+						return;
+
 					/* Store the new tuple for conflict reporting */
 					slot_store_data(newslot, part_entry, newtup);
 
@@ -3100,6 +3168,9 @@ apply_handle_tuple_routing(ApplyExecutionData *edata,
 					conflicttuple.origin != replorigin_session_origin)
 				{
 					TupleTableSlot *newslot;
+
+					if (is_prefetching())
+						return;
 
 					/* Store the new tuple for conflict reporting */
 					newslot = table_slot_create(partrel, &estate->es_tupleTable);
@@ -3370,21 +3441,6 @@ apply_dispatch(StringInfo s)
 	LogicalRepMsgType action = pq_getmsgbyte(s);
 	LogicalRepMsgType saved_command;
 
-	if (am_parallel_apply_worker() && MyParallelShared->do_prefetch)
-	{
-		switch (action)
-		{
-			case LOGICAL_REP_MSG_INSERT:
-			case LOGICAL_REP_MSG_UPDATE:
-			case LOGICAL_REP_MSG_DELETE:
-				pa_prefetch_handle_modification(s, action);
-				break;
-			default:
-				break;
-		}
-		return;
-	}
-
 	/*
 	 * Set the current command being applied. Since this function can be
 	 * called recursively when applying spooled changes, save the current
@@ -3581,14 +3637,40 @@ UpdateWorkerStats(XLogRecPtr last_lsn, TimestampTz send_time, bool reply)
 	}
 }
 
-static ParallelApplyWorkerInfo* prefetch_workers[MAX_LR_PREFETCH_WORKERS];
-static int prefetch_worker_rr = 0;
+#define MSG_CODE_OFFSET (1 + 8*3)
 
 static void
 lr_do_prefetch(char* buf, int len)
 {
-	ParallelApplyWorkerInfo* winfo = prefetch_workers[prefetch_worker_rr++ % lr_perfetch_workers];
-	pa_send_data(winfo, len, buf);
+	ParallelApplyWorkerInfo* winfo;
+
+	if (buf[0] != 'w')
+		return;
+
+	switch (buf[MSG_CODE_OFFSET])
+	{
+		case LOGICAL_REP_MSG_INSERT:
+		case LOGICAL_REP_MSG_UPDATE:
+		case LOGICAL_REP_MSG_DELETE:
+			/* Round robin prefetch worker */
+			winfo = prefetch_worker[prefetch_worker_rr++ % n_prefetch_workers];
+			pa_send_data(winfo, len, buf);
+			break;
+
+		case LOGICAL_REP_MSG_TYPE:
+		case LOGICAL_REP_MSG_RELATION:
+			/* broadcast to all prefetch workers */
+			for (int i = 0; i < n_prefetch_workers; i++)
+			{
+				winfo = prefetch_worker[i];
+				pa_send_data(winfo, len, buf);
+			}
+			break;
+
+		default:
+			/* Ignore other messages */
+			break;
+	}
 }
 
 /*
@@ -3622,22 +3704,23 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 													"LogicalStreamingContext",
 													ALLOCSET_DEFAULT_SIZES);
 
-	if (lr_prefetch_workers != 0)
+	if (max_parallel_prefetch_workers_per_subscription != 0)
 	{
-		for (int i = 0; i < lr_prefetch_workers; i++)
+		int i;
+		for (i = 0; i < max_parallel_prefetch_workers_per_subscription; i++)
 		{
 			prefetch_worker[i] = pa_launch_parallel_worker();
 			if (!prefetch_worker[i])
 			{
 				elog(LOG, "Launch only %d prefetch worklers from %d",
-					 i, lr_prefetch_workers);
-				lr_prefetch_workers = i;
+					 i, max_parallel_prefetch_workers_per_subscription);
 				break;
 			}
-			prefetch_worker[i]->is_use = true;
+			prefetch_worker[i]->in_use = true;
 			prefetch_worker[i]->shared->do_prefetch = true;
 		}
-		prefetch_buffer = palloc(prefetch_buffer_size);
+		n_prefetch_workers = i;
+		prefetch_buf = palloc(prefetch_buf_size);
 	}
 
 	/* mark as idle, before starting to loop */
@@ -3668,14 +3751,15 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 
 		len = walrcv_receive(LogRepWorkerWalRcvConn, &buf, &fd);
 
-		if (len > 0 && lr_prefetch_workers != 0)
+		if (len > 0 && n_prefetch_workers != 0)
 		{
+			prefetch_buf_used = 0;
 			while (len > 0)
 			{
-				if (prefetch_buf_used + len + 4 < prefetch_buf_size)
+				if (prefetch_buf_used + len + 4 > prefetch_buf_size)
 				{
-					prefetch_buf_size *- 2;
-					prefetch_buf = prealloc(prefetch_buf, prefetch_buf_size);
+					prefetch_buf_size *= 2;
+					prefetch_buf = repalloc(prefetch_buf, prefetch_buf_size);
 				}
 				memcpy(&prefetch_buf[prefetch_buf_used], &len, 4);
 				memcpy(&prefetch_buf[prefetch_buf_used+4], buf, len);
@@ -3772,7 +3856,7 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 
 					MemoryContextReset(ApplyMessageContext);
 				}
-				if (lr_prefetch_workers != 0)
+				if (n_prefetch_workers != 0)
 				{
 					if (prefetch_buf_pos < prefetch_buf_used)
 					{

--- a/src/backend/replication/logical/worker.c
+++ b/src/backend/replication/logical/worker.c
@@ -316,7 +316,7 @@ static ParallelApplyWorkerInfo* prefetch_worker[MAX_LR_PREFETCH_WORKERS];
 static int prefetch_worker_rr = 0;
 static int n_prefetch_workers;
 
-bool prefetch_replica_identity_only = true;
+bool prefetch_replica_identity_only = false;
 
 size_t lr_prefetch_hits;
 size_t lr_prefetch_misses;
@@ -340,11 +340,6 @@ size_t lr_prefetch_inserts;
  */
 static XLogRecPtr skip_xact_finish_lsn = InvalidXLogRecPtr;
 #define is_skipping_changes() (unlikely(!XLogRecPtrIsInvalid(skip_xact_finish_lsn)))
-
-/*
- * If operation is performed by parallel prefetch worker
- */
-#define is_prefetching()	(am_parallel_apply_worker() && MyParallelShared->do_prefetch)
 
 /* BufFile handle of the current streaming file */
 static BufFile *stream_fd = NULL;
@@ -499,6 +494,9 @@ should_apply_changes_for_rel(LogicalRepRelMapEntry *rel)
 					(rel->state == SUBREL_STATE_SYNCDONE &&
 					 rel->statelsn <= remote_final_lsn));
 
+		case WORKERTYPE_PARALLEL_PREFETCH:
+			return true;
+
 		case WORKERTYPE_UNKNOWN:
 			/* Should never happen. */
 			elog(ERROR, "Unknown worker type");
@@ -573,7 +571,7 @@ handle_streamed_transaction(LogicalRepMsgType action, StringInfo s)
 	TransApplyAction apply_action;
 	StringInfoData original_msg;
 
-	if (is_prefetching())
+	if (am_parallel_prefetch_worker())
 	{
 		return false;
 	}
@@ -2402,27 +2400,6 @@ TargetPrivilegesCheck(Relation rel, AclMode mode)
 						RelationGetRelationName(rel))));
 }
 
-#define SAFE_APPLY(call)									\
-	if (is_prefetching())									\
-	{														\
-		PG_TRY();											\
-		{													\
-			call;											\
-		}													\
-		PG_CATCH();											\
-		{													\
-			HOLD_INTERRUPTS();								\
-			elog(DEBUG1, "Failed to prefetch LR operation");\
-			FlushErrorState();								\
-			RESUME_INTERRUPTS();							\
-			lr_prefetch_errors += 1;						\
-		}													\
-		PG_END_TRY();										\
-	} else {												\
-		call;												\
-	}
-
-
 /*
  * Handle INSERT message.
  */
@@ -2496,7 +2473,7 @@ apply_handle_insert(StringInfo s)
 		ResultRelInfo *relinfo = edata->targetRelInfo;
 
 		ExecOpenIndices(relinfo, false);
-		SAFE_APPLY(apply_handle_insert_internal(edata, relinfo, remoteslot));
+		apply_handle_insert_internal(edata, relinfo, remoteslot);
 		ExecCloseIndices(relinfo);
 	}
 
@@ -2530,19 +2507,25 @@ apply_handle_insert_internal(ApplyExecutionData *edata,
 		   !relinfo->ri_RelationDesc->rd_rel->relhasindex ||
 		   RelationGetIndexList(relinfo->ri_RelationDesc) == NIL);
 
-	if (is_prefetching() && prefetch_replica_identity_only)
+	if (am_parallel_prefetch_worker())
 	{
-		TupleTableSlot *localslot = NULL;
+		Relation localrel = relinfo->ri_RelationDesc;
+		TupleTableSlot *localslot = table_slot_create(localrel, &estate->es_tupleTable);
 		LogicalRepRelMapEntry *relmapentry = edata->targetRel;
-		Relation		localrel = relinfo->ri_RelationDesc;
-		EPQState		epqstate;
 
-		EvalPlanQualInit(&epqstate, estate, NULL, NIL, -1, NIL);
-
-		(void)FindReplTupleInLocalRel(edata, localrel,
-									  &relmapentry->remoterel,
-									  relmapentry->localindexoid,
-									  remoteslot, &localslot);
+		if (prefetch_replica_identity_only)
+		{
+			(void)RelationPrefetchIndex(localrel, relmapentry->localindexoid, remoteslot, localslot);
+		}
+		else
+		{
+			for (int i = 0; i < relinfo->ri_NumIndices; i++)
+			{
+				Oid sec_index_oid = RelationGetRelid(relinfo->ri_IndexRelationDescs[i]);
+				(void)RelationPrefetchIndex(localrel, sec_index_oid, remoteslot, localslot);
+			}
+		}
+		lr_prefetch_inserts += 1;
 	}
 	else
 	{
@@ -2552,11 +2535,7 @@ apply_handle_insert_internal(ApplyExecutionData *edata,
 
 		/* Do the insert. */
 		TargetPrivilegesCheck(relinfo->ri_RelationDesc, ACL_INSERT);
-		ExecSimpleRelationInsert(relinfo, estate, remoteslot, is_prefetching());
-	}
-	if (is_prefetching())
-	{
-		lr_prefetch_inserts += 1;
+		ExecSimpleRelationInsert(relinfo, estate, remoteslot);
 	}
 }
 
@@ -2701,8 +2680,8 @@ apply_handle_update(StringInfo s)
 		apply_handle_tuple_routing(edata,
 								   remoteslot, &newtup, CMD_UPDATE);
 	else
-		SAFE_APPLY(apply_handle_update_internal(edata, edata->targetRelInfo,
-												remoteslot, &newtup, rel->localindexoid));
+		apply_handle_update_internal(edata, edata->targetRelInfo,
+									 remoteslot, &newtup, rel->localindexoid);
 
 	finish_edata(edata);
 
@@ -2741,20 +2720,36 @@ apply_handle_update_internal(ApplyExecutionData *edata,
 	EvalPlanQualInit(&epqstate, estate, NULL, NIL, -1, NIL);
 	ExecOpenIndices(relinfo, false);
 
-	found = FindReplTupleInLocalRel(edata, localrel,
-									&relmapentry->remoterel,
-									localindexoid,
-									remoteslot, &localslot);
-
-	if (is_prefetching())
+	if (am_parallel_prefetch_worker())
 	{
+		/*
+		 * While it may be reasonable to prefetch indexes for both old and new tuples,
+		 * we do it only for one of them (old if it exists,  new otherwise), assuming
+		 * that probability that index key is changed is quite small
+		 */
+		localslot = table_slot_create(localrel, &estate->es_tupleTable);
+		found = RelationPrefetchIndex(localrel, localindexoid, remoteslot, localslot);
 		if (found)
 			lr_prefetch_hits += 1;
 		else
 			lr_prefetch_misses += 1;
-		if (prefetch_replica_identity_only)
-			goto Cleanup;
+		if (!prefetch_replica_identity_only)
+		{
+			for (int i = 0; i < relinfo->ri_NumIndices; i++)
+			{
+				Oid sec_index_oid = RelationGetRelid(relinfo->ri_IndexRelationDescs[i]);
+				if (sec_index_oid != localindexoid)
+				{
+					(void)RelationPrefetchIndex(localrel, sec_index_oid, remoteslot, localslot);
+				}
+			}
+		}
+		goto Cleanup;
 	}
+	found = FindReplTupleInLocalRel(edata, localrel,
+									&relmapentry->remoterel,
+									localindexoid,
+									remoteslot, &localslot);
 
 	/*
 	 * Tuple found.
@@ -2796,7 +2791,7 @@ apply_handle_update_internal(ApplyExecutionData *edata,
 		/* Do the actual update. */
 		TargetPrivilegesCheck(relinfo->ri_RelationDesc, ACL_UPDATE);
 		ExecSimpleRelationUpdate(relinfo, estate, &epqstate, localslot,
-								 remoteslot, is_prefetching());
+								 remoteslot);
 	}
 	else
 	{
@@ -2894,8 +2889,8 @@ apply_handle_delete(StringInfo s)
 		ResultRelInfo *relinfo = edata->targetRelInfo;
 
 		ExecOpenIndices(relinfo, false);
-		SAFE_APPLY(apply_handle_delete_internal(edata, relinfo,
-												remoteslot, rel->localindexoid));
+		apply_handle_delete_internal(edata, relinfo,
+									 remoteslot, rel->localindexoid);
 		ExecCloseIndices(relinfo);
 	}
 
@@ -2938,17 +2933,19 @@ apply_handle_delete_internal(ApplyExecutionData *edata,
 		   !localrel->rd_rel->relhasindex ||
 		   RelationGetIndexList(localrel) == NIL);
 
-	found = FindReplTupleInLocalRel(edata, localrel, remoterel, localindexoid,
-									remoteslot, &localslot);
-
-	if (is_prefetching())
+	if (am_parallel_prefetch_worker())
 	{
+		localslot = table_slot_create(localrel, &estate->es_tupleTable);
+		found = RelationPrefetchIndex(localrel, localindexoid, remoteslot, localslot);
 		if (found)
 			lr_prefetch_hits += 1;
 		else
 			lr_prefetch_misses += 1;
+		/* No need to prefdetch other indexes because the are not touched during delete */
 		goto Cleanup;
 	}
+	found = FindReplTupleInLocalRel(edata, localrel, remoterel, localindexoid,
+									remoteslot, &localslot);
 
 	/* If found delete it. */
 	if (found)
@@ -3004,8 +3001,6 @@ FindReplTupleInLocalRel(ApplyExecutionData *edata, Relation localrel,
 	EState	   *estate = edata->estate;
 	bool		found;
 
-	LockTupleMode lockmode = is_prefetching() ? prefetch_replica_identity_only ? LockTupleNoLock : LockTupleTryExclusive : LockTupleExclusive;
-
 	/*
 	 * Regardless of the top-level operation, we're performing a read here, so
 	 * check for SELECT privileges.
@@ -3031,11 +3026,11 @@ FindReplTupleInLocalRel(ApplyExecutionData *edata, Relation localrel,
 #endif
 
 		found = RelationFindReplTupleByIndex(localrel, localidxoid,
-											 lockmode,
+											 LockTupleExclusive,
 											 remoteslot, *localslot);
 	}
 	else
-		found = RelationFindReplTupleSeq(localrel, lockmode,
+		found = RelationFindReplTupleSeq(localrel, LockTupleExclusive,
 										 remoteslot, *localslot);
 
 	return found;
@@ -3126,14 +3121,14 @@ apply_handle_tuple_routing(ApplyExecutionData *edata,
 	switch (operation)
 	{
 		case CMD_INSERT:
-			SAFE_APPLY(apply_handle_insert_internal(edata, partrelinfo,
-													remoteslot_part));
+			apply_handle_insert_internal(edata, partrelinfo,
+										 remoteslot_part);
 			break;
 
 		case CMD_DELETE:
-			SAFE_APPLY(apply_handle_delete_internal(edata, partrelinfo,
-													remoteslot_part,
-													part_entry->localindexoid));
+			apply_handle_delete_internal(edata, partrelinfo,
+										 remoteslot_part,
+										 part_entry->localindexoid);
 			break;
 
 		case CMD_UPDATE:
@@ -3161,9 +3156,6 @@ apply_handle_tuple_routing(ApplyExecutionData *edata,
 				{
 					TupleTableSlot *newslot = localslot;
 
-					if (is_prefetching())
-						return;
-
 					/* Store the new tuple for conflict reporting */
 					slot_store_data(newslot, part_entry, newtup);
 
@@ -3188,9 +3180,6 @@ apply_handle_tuple_routing(ApplyExecutionData *edata,
 					conflicttuple.origin != replorigin_session_origin)
 				{
 					TupleTableSlot *newslot;
-
-					if (is_prefetching())
-						return;
 
 					/* Store the new tuple for conflict reporting */
 					newslot = table_slot_create(partrel, &estate->es_tupleTable);
@@ -3235,7 +3224,7 @@ apply_handle_tuple_routing(ApplyExecutionData *edata,
 					TargetPrivilegesCheck(partrelinfo->ri_RelationDesc,
 										  ACL_UPDATE);
 					ExecSimpleRelationUpdate(partrelinfo, estate, &epqstate,
-											 localslot, remoteslot_part, is_prefetching());
+											 localslot, remoteslot_part);
 				}
 				else
 				{
@@ -3308,8 +3297,8 @@ apply_handle_tuple_routing(ApplyExecutionData *edata,
 						slot_getallattrs(remoteslot);
 					}
 					MemoryContextSwitchTo(oldctx);
-					SAFE_APPLY(apply_handle_insert_internal(edata, partrelinfo_new,
-															remoteslot_part));
+					apply_handle_insert_internal(edata, partrelinfo_new,
+												 remoteslot_part);
 				}
 
 				EvalPlanQualEnd(&epqstate);
@@ -3643,6 +3632,7 @@ store_flush_position(XLogRecPtr remote_lsn, XLogRecPtr local_lsn)
 	MemoryContextSwitchTo(ApplyMessageContext);
 }
 
+
 /* Update statistics of the worker. */
 static void
 UpdateWorkerStats(XLogRecPtr last_lsn, TimestampTz send_time, bool reply)
@@ -3729,15 +3719,13 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 		int i;
 		for (i = 0; i < max_parallel_prefetch_workers_per_subscription; i++)
 		{
-			prefetch_worker[i] = pa_launch_parallel_worker();
+			prefetch_worker[i] = pa_launch_prefetch_worker();
 			if (!prefetch_worker[i])
 			{
 				elog(LOG, "Launch only %d prefetch workers from %d",
 					 i, max_parallel_prefetch_workers_per_subscription);
 				break;
 			}
-			prefetch_worker[i]->in_use = true;
-			prefetch_worker[i]->shared->do_prefetch = true;
 		}
 		n_prefetch_workers = i;
 		prefetch_buf = palloc(prefetch_buf_size);
@@ -3761,7 +3749,7 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 		pgsocket	fd = PGINVALID_SOCKET;
 		int			rc;
 		int32		len;
-		char	   *buf = NULL;
+		char		*buf = NULL;
 		bool		endofstream = false;
 		bool		no_more_data = false;
 		long		wait_time;
@@ -4116,6 +4104,10 @@ send_feedback(XLogRecPtr recvpos, bool force, bool requestReply)
 static void
 apply_worker_exit(void)
 {
+	/* Don't restart prefetch workers */
+	if (am_parallel_prefetch_worker())
+		return;
+
 	if (am_parallel_apply_worker())
 	{
 		/*
@@ -4919,6 +4911,10 @@ InitializeLogRepWorker(void)
 				(errmsg("logical replication table synchronization worker for subscription \"%s\", table \"%s\" has started",
 						MySubscription->name,
 						get_rel_name(MyLogicalRepWorker->relid))));
+	else if (am_parallel_prefetch_worker())
+		ereport(LOG,
+				(errmsg("logical replication prefetch worker for subscription \"%s\" has started",
+						MySubscription->name)));
 	else
 		ereport(LOG,
 				(errmsg("logical replication apply worker for subscription \"%s\" has started",

--- a/src/backend/replication/logical/worker.c
+++ b/src/backend/replication/logical/worker.c
@@ -3370,6 +3370,21 @@ apply_dispatch(StringInfo s)
 	LogicalRepMsgType action = pq_getmsgbyte(s);
 	LogicalRepMsgType saved_command;
 
+	if (am_parallel_apply_worker() && MyParallelShared->do_prefetch)
+	{
+		switch (action)
+		{
+			case LOGICAL_REP_MSG_INSERT:
+			case LOGICAL_REP_MSG_UPDATE:
+			case LOGICAL_REP_MSG_DELETE:
+				pa_prefetch_handle_modification(s, action);
+				break;
+			default:
+				break;
+		}
+		return;
+	}
+
 	/*
 	 * Set the current command being applied. Since this function can be
 	 * called recursively when applying spooled changes, save the current
@@ -3552,7 +3567,6 @@ store_flush_position(XLogRecPtr remote_lsn, XLogRecPtr local_lsn)
 	MemoryContextSwitchTo(ApplyMessageContext);
 }
 
-
 /* Update statistics of the worker. */
 static void
 UpdateWorkerStats(XLogRecPtr last_lsn, TimestampTz send_time, bool reply)
@@ -3567,6 +3581,16 @@ UpdateWorkerStats(XLogRecPtr last_lsn, TimestampTz send_time, bool reply)
 	}
 }
 
+static ParallelApplyWorkerInfo* prefetch_workers[MAX_LR_PREFETCH_WORKERS];
+static int prefetch_worker_rr = 0;
+
+static void
+lr_do_prefetch(char* buf, int len)
+{
+	ParallelApplyWorkerInfo* winfo = prefetch_workers[prefetch_worker_rr++ % lr_perfetch_workers];
+	pa_send_data(winfo, len, buf);
+}
+
 /*
  * Apply main loop.
  */
@@ -3577,6 +3601,10 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 	bool		ping_sent = false;
 	TimeLineID	tli;
 	ErrorContextCallback errcallback;
+    char* prefetch_buf = NULL;
+	size_t prefetch_buf_pos = 0;
+	size_t prefetch_buf_used = 0;
+	size_t prefetch_buf_size = INIT_PREFETCH_BUF_SIZE;
 
 	/*
 	 * Init the ApplyMessageContext which we clean up after each replication
@@ -3593,6 +3621,24 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 	LogicalStreamingContext = AllocSetContextCreate(ApplyContext,
 													"LogicalStreamingContext",
 													ALLOCSET_DEFAULT_SIZES);
+
+	if (lr_prefetch_workers != 0)
+	{
+		for (int i = 0; i < lr_prefetch_workers; i++)
+		{
+			prefetch_worker[i] = pa_launch_parallel_worker();
+			if (!prefetch_worker[i])
+			{
+				elog(LOG, "Launch only %d prefetch worklers from %d",
+					 i, lr_prefetch_workers);
+				lr_prefetch_workers = i;
+				break;
+			}
+			prefetch_worker[i]->is_use = true;
+			prefetch_worker[i]->shared->do_prefetch = true;
+		}
+		prefetch_buffer = palloc(prefetch_buffer_size);
+	}
 
 	/* mark as idle, before starting to loop */
 	pgstat_report_activity(STATE_IDLE, NULL);
@@ -3611,7 +3657,7 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 	{
 		pgsocket	fd = PGINVALID_SOCKET;
 		int			rc;
-		int			len;
+		int32		len;
 		char	   *buf = NULL;
 		bool		endofstream = false;
 		long		wait_time;
@@ -3621,6 +3667,30 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 		MemoryContextSwitchTo(ApplyMessageContext);
 
 		len = walrcv_receive(LogRepWorkerWalRcvConn, &buf, &fd);
+
+		if (len > 0 && lr_prefetch_workers != 0)
+		{
+			while (len > 0)
+			{
+				if (prefetch_buf_used + len + 4 < prefetch_buf_size)
+				{
+					prefetch_buf_size *- 2;
+					prefetch_buf = prealloc(prefetch_buf, prefetch_buf_size);
+				}
+				memcpy(&prefetch_buf[prefetch_buf_used], &len, 4);
+				memcpy(&prefetch_buf[prefetch_buf_used+4], buf, len);
+				prefetch_buf_used += 4 + len;
+				len = walrcv_receive(LogRepWorkerWalRcvConn, &buf, &fd);
+			}
+			for (prefetch_buf_pos = 0; prefetch_buf_pos < prefetch_buf_used; prefetch_buf_pos += 4 + len)
+			{
+				memcpy(&len, &prefetch_buf[prefetch_buf_pos], 4);
+				lr_do_prefetch(&prefetch_buf[prefetch_buf_pos+4], len);
+			}
+			memcpy(&len, prefetch_buf, 4);
+			buf = &prefetch_buf[4];
+			prefetch_buf_pos = len + 4;
+		}
 
 		if (len != 0)
 		{
@@ -3702,8 +3772,23 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 
 					MemoryContextReset(ApplyMessageContext);
 				}
-
-				len = walrcv_receive(LogRepWorkerWalRcvConn, &buf, &fd);
+				if (lr_prefetch_workers != 0)
+				{
+					if (prefetch_buf_pos < prefetch_buf_used)
+					{
+						memcpy(&len, &prefetch_buf[prefetch_buf_pos], 4);
+						buf = &prefetch_buf[prefetch_buf_pos + 4];
+						prefetch_buf_pos += 4 + len;
+					}
+					else
+					{
+						len = 0;
+					}
+				}
+				else
+				{
+					len = walrcv_receive(LogRepWorkerWalRcvConn, &buf, &fd);
+				}
 			}
 		}
 

--- a/src/backend/replication/logical/worker.c
+++ b/src/backend/replication/logical/worker.c
@@ -3683,7 +3683,7 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 	bool		ping_sent = false;
 	TimeLineID	tli;
 	ErrorContextCallback errcallback;
-    char* prefetch_buf = NULL;
+	char* prefetch_buf = NULL;
 	size_t prefetch_buf_pos = 0;
 	size_t prefetch_buf_used = 0;
 	size_t prefetch_buf_size = INIT_PREFETCH_BUF_SIZE;

--- a/src/backend/replication/logical/worker.c
+++ b/src/backend/replication/logical/worker.c
@@ -311,7 +311,7 @@ static uint32 parallel_stream_nchanges = 0;
 /* Are we initializing an apply worker? */
 bool		InitializingApplyWorker = false;
 
-#define INIT_PREFETCH_BUF_SIZE (64*1024)
+#define INIT_PREFETCH_BUF_SIZE (128*1024)
 static ParallelApplyWorkerInfo* prefetch_worker[MAX_LR_PREFETCH_WORKERS];
 static int prefetch_worker_rr = 0;
 static int n_prefetch_workers;
@@ -2402,6 +2402,27 @@ TargetPrivilegesCheck(Relation rel, AclMode mode)
 						RelationGetRelationName(rel))));
 }
 
+#define SAFE_APPLY(call)									\
+	if (is_prefetching())									\
+	{														\
+		PG_TRY();											\
+		{													\
+			call;											\
+		}													\
+		PG_CATCH();											\
+		{													\
+			HOLD_INTERRUPTS();								\
+			elog(DEBUG1, "Failed to prefetch LR operation");\
+			FlushErrorState();								\
+			RESUME_INTERRUPTS();							\
+			lr_prefetch_errors += 1;						\
+		}													\
+		PG_END_TRY();										\
+	} else {												\
+		call;												\
+	}
+
+
 /*
  * Handle INSERT message.
  */
@@ -2475,7 +2496,7 @@ apply_handle_insert(StringInfo s)
 		ResultRelInfo *relinfo = edata->targetRelInfo;
 
 		ExecOpenIndices(relinfo, false);
-		apply_handle_insert_internal(edata, relinfo, remoteslot);
+		SAFE_APPLY(apply_handle_insert_internal(edata, relinfo, remoteslot));
 		ExecCloseIndices(relinfo);
 	}
 
@@ -2517,7 +2538,6 @@ apply_handle_insert_internal(ApplyExecutionData *edata,
 		EPQState		epqstate;
 
 		EvalPlanQualInit(&epqstate, estate, NULL, NIL, -1, NIL);
-		ExecOpenIndices(relinfo, false);
 
 		(void)FindReplTupleInLocalRel(edata, localrel,
 									  &relmapentry->remoterel,
@@ -2681,8 +2701,8 @@ apply_handle_update(StringInfo s)
 		apply_handle_tuple_routing(edata,
 								   remoteslot, &newtup, CMD_UPDATE);
 	else
-		apply_handle_update_internal(edata, edata->targetRelInfo,
-									 remoteslot, &newtup, rel->localindexoid);
+		SAFE_APPLY(apply_handle_update_internal(edata, edata->targetRelInfo,
+												remoteslot, &newtup, rel->localindexoid));
 
 	finish_edata(edata);
 
@@ -2874,8 +2894,8 @@ apply_handle_delete(StringInfo s)
 		ResultRelInfo *relinfo = edata->targetRelInfo;
 
 		ExecOpenIndices(relinfo, false);
-		apply_handle_delete_internal(edata, relinfo,
-									 remoteslot, rel->localindexoid);
+		SAFE_APPLY(apply_handle_delete_internal(edata, relinfo,
+												remoteslot, rel->localindexoid));
 		ExecCloseIndices(relinfo);
 	}
 
@@ -3106,14 +3126,14 @@ apply_handle_tuple_routing(ApplyExecutionData *edata,
 	switch (operation)
 	{
 		case CMD_INSERT:
-			apply_handle_insert_internal(edata, partrelinfo,
-										 remoteslot_part);
+			SAFE_APPLY(apply_handle_insert_internal(edata, partrelinfo,
+													remoteslot_part));
 			break;
 
 		case CMD_DELETE:
-			apply_handle_delete_internal(edata, partrelinfo,
-										 remoteslot_part,
-										 part_entry->localindexoid);
+			SAFE_APPLY(apply_handle_delete_internal(edata, partrelinfo,
+													remoteslot_part,
+													part_entry->localindexoid));
 			break;
 
 		case CMD_UPDATE:
@@ -3288,8 +3308,8 @@ apply_handle_tuple_routing(ApplyExecutionData *edata,
 						slot_getallattrs(remoteslot);
 					}
 					MemoryContextSwitchTo(oldctx);
-					apply_handle_insert_internal(edata, partrelinfo_new,
-												 remoteslot_part);
+					SAFE_APPLY(apply_handle_insert_internal(edata, partrelinfo_new,
+															remoteslot_part));
 				}
 
 				EvalPlanQualEnd(&epqstate);
@@ -3743,6 +3763,7 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 		int32		len;
 		char	   *buf = NULL;
 		bool		endofstream = false;
+		bool		no_more_data = false;
 		long		wait_time;
 
 		CHECK_FOR_INTERRUPTS();
@@ -3751,128 +3772,128 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 
 		len = walrcv_receive(LogRepWorkerWalRcvConn, &buf, &fd);
 
-		if (len > 0 && n_prefetch_workers != 0)
+		/* Loop to process all available data (without blocking). */
+		for (;;)
 		{
-			prefetch_buf_used = 0;
-			while (len > 0)
+			CHECK_FOR_INTERRUPTS();
+
+			if (len > 0 && n_prefetch_workers != 0 && prefetch_buf_pos == prefetch_buf_used)
 			{
-				if (prefetch_buf_used + len + 4 > prefetch_buf_size)
+				prefetch_buf_used = 0;
+				do
 				{
-					prefetch_buf_size *= 2;
-					prefetch_buf = repalloc(prefetch_buf, prefetch_buf_size);
+					if (prefetch_buf_used + len + 4 > prefetch_buf_size)
+					{
+						prefetch_buf_size *= 2;
+						elog(DEUG1, "Increase prefetch buffer size to %ld", prefetch_buf_size);
+						prefetch_buf = repalloc(prefetch_buf, prefetch_buf_size);
+					}
+					memcpy(&prefetch_buf[prefetch_buf_used], &len, 4);
+					memcpy(&prefetch_buf[prefetch_buf_used+4], buf, len);
+					prefetch_buf_used += 4 + len;
+					if (prefetch_buf_used >= INIT_PREFETCH_BUF_SIZE)
+						break;
+					len = walrcv_receive(LogRepWorkerWalRcvConn, &buf, &fd);
+				} while (len > 0);
+
+				no_more_data = len <= 0;
+
+				for (prefetch_buf_pos = 0; prefetch_buf_pos < prefetch_buf_used; prefetch_buf_pos += 4 + len)
+				{
+					memcpy(&len, &prefetch_buf[prefetch_buf_pos], 4);
+					lr_do_prefetch(&prefetch_buf[prefetch_buf_pos+4], len);
 				}
-				memcpy(&prefetch_buf[prefetch_buf_used], &len, 4);
-				memcpy(&prefetch_buf[prefetch_buf_used+4], buf, len);
-				prefetch_buf_used += 4 + len;
-				len = walrcv_receive(LogRepWorkerWalRcvConn, &buf, &fd);
+				memcpy(&len, prefetch_buf, 4);
+				buf = &prefetch_buf[4];
+				prefetch_buf_pos = len + 4;
 			}
-			for (prefetch_buf_pos = 0; prefetch_buf_pos < prefetch_buf_used; prefetch_buf_pos += 4 + len)
+
+			if (len == 0)
+			{
+				break;
+			}
+			else if (len < 0)
+			{
+				ereport(LOG,
+						(errmsg("data stream from publisher has ended")));
+				endofstream = true;
+				break;
+			}
+			else
+			{
+				int			c;
+				StringInfoData s;
+
+				if (ConfigReloadPending)
+				{
+					ConfigReloadPending = false;
+					ProcessConfigFile(PGC_SIGHUP);
+				}
+
+				/* Reset timeout. */
+				last_recv_timestamp = GetCurrentTimestamp();
+				ping_sent = false;
+
+				/* Ensure we are reading the data into our memory context. */
+				MemoryContextSwitchTo(ApplyMessageContext);
+
+				initReadOnlyStringInfo(&s, buf, len);
+
+				c = pq_getmsgbyte(&s);
+
+				if (c == 'w')
+				{
+					XLogRecPtr	start_lsn;
+					XLogRecPtr	end_lsn;
+					TimestampTz send_time;
+
+					start_lsn = pq_getmsgint64(&s);
+					end_lsn = pq_getmsgint64(&s);
+					send_time = pq_getmsgint64(&s);
+
+					if (last_received < start_lsn)
+						last_received = start_lsn;
+
+					if (last_received < end_lsn)
+						last_received = end_lsn;
+
+					UpdateWorkerStats(last_received, send_time, false);
+
+					apply_dispatch(&s);
+				}
+				else if (c == 'k')
+				{
+					XLogRecPtr	end_lsn;
+					TimestampTz timestamp;
+					bool		reply_requested;
+
+					end_lsn = pq_getmsgint64(&s);
+					timestamp = pq_getmsgint64(&s);
+					reply_requested = pq_getmsgbyte(&s);
+
+					if (last_received < end_lsn)
+						last_received = end_lsn;
+
+					send_feedback(last_received, reply_requested, false);
+					UpdateWorkerStats(last_received, timestamp, true);
+				}
+				/* other message types are purposefully ignored */
+
+				MemoryContextReset(ApplyMessageContext);
+			}
+			if (prefetch_buf_pos < prefetch_buf_used)
 			{
 				memcpy(&len, &prefetch_buf[prefetch_buf_pos], 4);
-				lr_do_prefetch(&prefetch_buf[prefetch_buf_pos+4], len);
+				buf = &prefetch_buf[prefetch_buf_pos + 4];
+				prefetch_buf_pos += 4 + len;
 			}
-			memcpy(&len, prefetch_buf, 4);
-			buf = &prefetch_buf[4];
-			prefetch_buf_pos = len + 4;
-		}
-
-		if (len != 0)
-		{
-			/* Loop to process all available data (without blocking). */
-			for (;;)
+			else if (prefetch_buf_used != 0 && no_more_data)
 			{
-				CHECK_FOR_INTERRUPTS();
-
-				if (len == 0)
-				{
-					break;
-				}
-				else if (len < 0)
-				{
-					ereport(LOG,
-							(errmsg("data stream from publisher has ended")));
-					endofstream = true;
-					break;
-				}
-				else
-				{
-					int			c;
-					StringInfoData s;
-
-					if (ConfigReloadPending)
-					{
-						ConfigReloadPending = false;
-						ProcessConfigFile(PGC_SIGHUP);
-					}
-
-					/* Reset timeout. */
-					last_recv_timestamp = GetCurrentTimestamp();
-					ping_sent = false;
-
-					/* Ensure we are reading the data into our memory context. */
-					MemoryContextSwitchTo(ApplyMessageContext);
-
-					initReadOnlyStringInfo(&s, buf, len);
-
-					c = pq_getmsgbyte(&s);
-
-					if (c == 'w')
-					{
-						XLogRecPtr	start_lsn;
-						XLogRecPtr	end_lsn;
-						TimestampTz send_time;
-
-						start_lsn = pq_getmsgint64(&s);
-						end_lsn = pq_getmsgint64(&s);
-						send_time = pq_getmsgint64(&s);
-
-						if (last_received < start_lsn)
-							last_received = start_lsn;
-
-						if (last_received < end_lsn)
-							last_received = end_lsn;
-
-						UpdateWorkerStats(last_received, send_time, false);
-
-						apply_dispatch(&s);
-					}
-					else if (c == 'k')
-					{
-						XLogRecPtr	end_lsn;
-						TimestampTz timestamp;
-						bool		reply_requested;
-
-						end_lsn = pq_getmsgint64(&s);
-						timestamp = pq_getmsgint64(&s);
-						reply_requested = pq_getmsgbyte(&s);
-
-						if (last_received < end_lsn)
-							last_received = end_lsn;
-
-						send_feedback(last_received, reply_requested, false);
-						UpdateWorkerStats(last_received, timestamp, true);
-					}
-					/* other message types are purposefully ignored */
-
-					MemoryContextReset(ApplyMessageContext);
-				}
-				if (n_prefetch_workers != 0)
-				{
-					if (prefetch_buf_pos < prefetch_buf_used)
-					{
-						memcpy(&len, &prefetch_buf[prefetch_buf_pos], 4);
-						buf = &prefetch_buf[prefetch_buf_pos + 4];
-						prefetch_buf_pos += 4 + len;
-					}
-					else
-					{
-						len = 0;
-					}
-				}
-				else
-				{
-					len = walrcv_receive(LogRepWorkerWalRcvConn, &buf, &fd);
-				}
+				break;
+			}
+			else
+			{
+				len = walrcv_receive(LogRepWorkerWalRcvConn, &buf, &fd);
 			}
 		}
 

--- a/src/backend/replication/logical/worker.c
+++ b/src/backend/replication/logical/worker.c
@@ -3785,7 +3785,7 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 					if (prefetch_buf_used + len + 4 > prefetch_buf_size)
 					{
 						prefetch_buf_size *= 2;
-						elog(DEUG1, "Increase prefetch buffer size to %ld", prefetch_buf_size);
+						elog(DEBUG1, "Increase prefetch buffer size to %ld", prefetch_buf_size);
 						prefetch_buf = repalloc(prefetch_buf, prefetch_buf_size);
 					}
 					memcpy(&prefetch_buf[prefetch_buf_used], &len, 4);

--- a/src/backend/replication/logical/worker.c
+++ b/src/backend/replication/logical/worker.c
@@ -2552,7 +2552,7 @@ apply_handle_insert_internal(ApplyExecutionData *edata,
 
 		/* Do the insert. */
 		TargetPrivilegesCheck(relinfo->ri_RelationDesc, ACL_INSERT);
-		ExecSimpleRelationInsert(relinfo, estate, remoteslot);
+		ExecSimpleRelationInsert(relinfo, estate, remoteslot, is_prefetching());
 	}
 	if (is_prefetching())
 	{
@@ -2796,7 +2796,7 @@ apply_handle_update_internal(ApplyExecutionData *edata,
 		/* Do the actual update. */
 		TargetPrivilegesCheck(relinfo->ri_RelationDesc, ACL_UPDATE);
 		ExecSimpleRelationUpdate(relinfo, estate, &epqstate, localslot,
-								 remoteslot);
+								 remoteslot, is_prefetching());
 	}
 	else
 	{
@@ -3235,7 +3235,7 @@ apply_handle_tuple_routing(ApplyExecutionData *edata,
 					TargetPrivilegesCheck(partrelinfo->ri_RelationDesc,
 										  ACL_UPDATE);
 					ExecSimpleRelationUpdate(partrelinfo, estate, &epqstate,
-											 localslot, remoteslot_part);
+											 localslot, remoteslot_part, is_prefetching());
 				}
 				else
 				{
@@ -3732,7 +3732,7 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 			prefetch_worker[i] = pa_launch_parallel_worker();
 			if (!prefetch_worker[i])
 			{
-				elog(LOG, "Launch only %d prefetch worklers from %d",
+				elog(LOG, "Launch only %d prefetch workers from %d",
 					 i, max_parallel_prefetch_workers_per_subscription);
 				break;
 			}

--- a/src/backend/utils/misc/guc_tables.c
+++ b/src/backend/utils/misc/guc_tables.c
@@ -76,6 +76,7 @@
 #include "replication/slot.h"
 #include "replication/slotsync.h"
 #include "replication/syncrep.h"
+#include "replication/worker_internal.h"
 #include "storage/aio.h"
 #include "storage/bufmgr.h"
 #include "storage/bufpage.h"
@@ -2139,6 +2140,18 @@ struct config_bool ConfigureNamesBool[] =
 			gettext_noop("Enables vacuum to truncate empty pages at the end of the table."),
 		},
 		&vacuum_truncate,
+		true,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"prefetch_replica_identity_only",
+			PGC_SIGHUP,
+			REPLICATION_SUBSCRIBERS,
+			gettext_noop("Whether LR prefetch work should prefetch only replica identity index or all other indexes too."),
+			NULL,
+		},
+		&prefetch_replica_identity_only,
 		true,
 		NULL, NULL, NULL
 	},

--- a/src/backend/utils/misc/guc_tables.c
+++ b/src/backend/utils/misc/guc_tables.c
@@ -2152,7 +2152,7 @@ struct config_bool ConfigureNamesBool[] =
 			NULL,
 		},
 		&prefetch_replica_identity_only,
-		true,
+		false,
 		NULL, NULL, NULL
 	},
 

--- a/src/backend/utils/misc/guc_tables.c
+++ b/src/backend/utils/misc/guc_tables.c
@@ -3377,6 +3377,18 @@ struct config_int ConfigureNamesInt[] =
 	},
 
 	{
+		{"max_parallel_prefetch_workers_per_subscription",
+			PGC_SIGHUP,
+			REPLICATION_SUBSCRIBERS,
+			gettext_noop("Maximum number of parallel prefetch workers per subscription."),
+			NULL,
+		},
+		&max_parallel_prefetch_workers_per_subscription,
+		2, 0, MAX_LR_PREFETCH_WORKERS,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"max_active_replication_origins",
 			PGC_POSTMASTER,
 			REPLICATION_SUBSCRIBERS,

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -759,12 +759,14 @@ extern bool RelationFindReplTupleByIndex(Relation rel, Oid idxoid,
 										 TupleTableSlot *outslot);
 extern bool RelationFindReplTupleSeq(Relation rel, LockTupleMode lockmode,
 									 TupleTableSlot *searchslot, TupleTableSlot *outslot);
+extern bool RelationPrefetchIndex(Relation rel, Oid idxoid, TupleTableSlot *searchslot,
+								  TupleTableSlot *outslot);
 
 extern void ExecSimpleRelationInsert(ResultRelInfo *resultRelInfo,
-									 EState *estate, TupleTableSlot *slot, bool prefetch);
+									 EState *estate, TupleTableSlot *slot);
 extern void ExecSimpleRelationUpdate(ResultRelInfo *resultRelInfo,
 									 EState *estate, EPQState *epqstate,
-									 TupleTableSlot *searchslot, TupleTableSlot *slot, bool prefetch);
+									 TupleTableSlot *searchslot, TupleTableSlot *slot);
 extern void ExecSimpleRelationDelete(ResultRelInfo *resultRelInfo,
 									 EState *estate, EPQState *epqstate,
 									 TupleTableSlot *searchslot);

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -761,10 +761,10 @@ extern bool RelationFindReplTupleSeq(Relation rel, LockTupleMode lockmode,
 									 TupleTableSlot *searchslot, TupleTableSlot *outslot);
 
 extern void ExecSimpleRelationInsert(ResultRelInfo *resultRelInfo,
-									 EState *estate, TupleTableSlot *slot);
+									 EState *estate, TupleTableSlot *slot, bool prefetch);
 extern void ExecSimpleRelationUpdate(ResultRelInfo *resultRelInfo,
 									 EState *estate, EPQState *epqstate,
-									 TupleTableSlot *searchslot, TupleTableSlot *slot);
+									 TupleTableSlot *searchslot, TupleTableSlot *slot, bool prefetch);
 extern void ExecSimpleRelationDelete(ResultRelInfo *resultRelInfo,
 									 EState *estate, EPQState *epqstate,
 									 TupleTableSlot *searchslot);

--- a/src/include/nodes/lockoptions.h
+++ b/src/include/nodes/lockoptions.h
@@ -56,6 +56,10 @@ typedef enum LockTupleMode
 	LockTupleNoKeyExclusive,
 	/* SELECT FOR UPDATE, UPDATEs that modify key columns, and DELETE */
 	LockTupleExclusive,
+	/* Do not lock tuple */
+	LockTupleNoLock,
+	/* Try explusive lock, silent give up in case of conflict */
+	LockTupleTryExclusive,
 } LockTupleMode;
 
 #endif							/* LOCKOPTIONS_H */

--- a/src/include/nodes/lockoptions.h
+++ b/src/include/nodes/lockoptions.h
@@ -56,10 +56,6 @@ typedef enum LockTupleMode
 	LockTupleNoKeyExclusive,
 	/* SELECT FOR UPDATE, UPDATEs that modify key columns, and DELETE */
 	LockTupleExclusive,
-	/* Do not lock tuple */
-	LockTupleNoLock,
-	/* Try explusive lock, silent give up in case of conflict */
-	LockTupleTryExclusive,
 } LockTupleMode;
 
 #endif							/* LOCKOPTIONS_H */

--- a/src/include/replication/logicallauncher.h
+++ b/src/include/replication/logicallauncher.h
@@ -15,6 +15,8 @@
 extern PGDLLIMPORT int max_logical_replication_workers;
 extern PGDLLIMPORT int max_sync_workers_per_subscription;
 extern PGDLLIMPORT int max_parallel_apply_workers_per_subscription;
+extern PGDLLIMPORT int max_parallel_apply_workers_per_subscription;
+extern PGDLLIMPORT int max_parallel_prefetch_workers_per_subscription;
 
 extern void ApplyLauncherRegister(void);
 extern void ApplyLauncherMain(Datum main_arg);

--- a/src/include/replication/worker_internal.h
+++ b/src/include/replication/worker_internal.h
@@ -180,6 +180,11 @@ typedef struct ParallelApplyWorkerShared
 	 */
 	PartialFileSetState fileset_state;
 	FileSet		fileset;
+
+	/*
+	 * Prefetch worker
+	 */
+	bool		do_prefetch;
 } ParallelApplyWorkerShared;
 
 /*

--- a/src/include/replication/worker_internal.h
+++ b/src/include/replication/worker_internal.h
@@ -32,6 +32,7 @@ typedef enum LogicalRepWorkerType
 	WORKERTYPE_TABLESYNC,
 	WORKERTYPE_APPLY,
 	WORKERTYPE_PARALLEL_APPLY,
+	WORKERTYPE_PARALLEL_PREFETCH,
 } LogicalRepWorkerType;
 
 typedef struct LogicalRepWorker
@@ -180,11 +181,6 @@ typedef struct ParallelApplyWorkerShared
 	 */
 	PartialFileSetState fileset_state;
 	FileSet		fileset;
-
-	/*
-	 * Prefetch worker
-	 */
-	bool		do_prefetch;
 } ParallelApplyWorkerShared;
 
 /*
@@ -218,6 +214,12 @@ typedef struct ParallelApplyWorkerInfo
 	 * transaction. False indicates this worker is available for re-use.
 	 */
 	bool		in_use;
+
+
+	/*
+	 * Performing prefetch of pages accessed by LR operations
+	 */
+	bool		do_prefetch;
 
 	ParallelApplyWorkerShared *shared;
 } ParallelApplyWorkerInfo;
@@ -339,13 +341,13 @@ extern void pa_decr_and_wait_stream_block(void);
 extern void pa_xact_finish(ParallelApplyWorkerInfo *winfo,
 						   XLogRecPtr remote_lsn);
 
-extern void pa_prefetch_handle_modification(StringInfo s, LogicalRepMsgType action);
-
 #define isParallelApplyWorker(worker) ((worker)->in_use &&			\
 									   (worker)->type == WORKERTYPE_PARALLEL_APPLY)
+#define isParallelPrefetchWorker(worker) ((worker)->in_use &&			\
+										  (worker)->type == WORKERTYPE_PARALLEL_PREFETCH)
 #define isTablesyncWorker(worker) ((worker)->in_use && \
 								   (worker)->type == WORKERTYPE_TABLESYNC)
-extern ParallelApplyWorkerInfo* pa_launch_parallel_worker(void);
+extern ParallelApplyWorkerInfo* pa_launch_prefetch_worker(void);
 
 static inline bool
 am_tablesync_worker(void)
@@ -365,6 +367,13 @@ am_parallel_apply_worker(void)
 {
 	Assert(MyLogicalRepWorker->in_use);
 	return isParallelApplyWorker(MyLogicalRepWorker);
+}
+
+static inline bool
+am_parallel_prefetch_worker(void)
+{
+	Assert(MyLogicalRepWorker->in_use);
+	return isParallelPrefetchWorker(MyLogicalRepWorker);
 }
 
 #endif							/* WORKER_INTERNAL_H */

--- a/src/include/replication/worker_internal.h
+++ b/src/include/replication/worker_internal.h
@@ -331,10 +331,13 @@ extern void pa_decr_and_wait_stream_block(void);
 extern void pa_xact_finish(ParallelApplyWorkerInfo *winfo,
 						   XLogRecPtr remote_lsn);
 
-#define isParallelApplyWorker(worker) ((worker)->in_use && \
+extern void pa_prefetch_handle_modification(StringInfo s, LogicalRepMsgType action);
+
+#define isParallelApplyWorker(worker) ((worker)->in_use &&			\
 									   (worker)->type == WORKERTYPE_PARALLEL_APPLY)
 #define isTablesyncWorker(worker) ((worker)->in_use && \
 								   (worker)->type == WORKERTYPE_TABLESYNC)
+extern ParallelApplyWorkerInfo* pa_launch_parallel_worker(void);
 
 static inline bool
 am_tablesync_worker(void)

--- a/src/include/replication/worker_internal.h
+++ b/src/include/replication/worker_internal.h
@@ -242,6 +242,14 @@ extern PGDLLIMPORT bool in_remote_transaction;
 
 extern PGDLLIMPORT bool InitializingApplyWorker;
 
+#define MAX_LR_PREFETCH_WORKERS 128
+extern PGDLLIMPORT size_t lr_prefetch_hits;
+extern PGDLLIMPORT size_t lr_prefetch_misses;
+extern PGDLLIMPORT size_t lr_prefetch_errors;
+extern PGDLLIMPORT size_t lr_prefetch_inserts;
+
+extern bool prefetch_replica_identity_only;
+
 extern void logicalrep_worker_attach(int slot);
 extern LogicalRepWorker *logicalrep_worker_find(Oid subid, Oid relid,
 												bool only_running);


### PR DESCRIPTION
There is well known Postgres problem that logical replication subscriber can not caught-up with publisher just because LR changes are applied by single worker and at publisher changes are made by
multiple concurrent backends. The problem is not logical replication specific: physical replication stream is also handled by single walreceiver. But for physical replication Postgres now implements prefetch: looking at WAL record blocks it is quite easy to predict which pages will be required for redo and prefetch them. With logical replication situation is much more complicated.

My first idea was to implement parallel apply of transactions. But to do it we need to track dependencies between transactions. Right now Postgres can apply transactions in parallel, but only if they are streamed or serialized (which is done only for large transactions) and serialize them by commits. It is possible to enforce parallel apply of short transactions using `debug_logical_replication_streaming` but then performance is ~2x times slower than in case of sequential apply by single worker. By removing serialization by commits, it is possible to speedup apply 3x times and make subscriber apply changes faster then producer can produce them even with multiple clients. But it is possible only if transactions are independent and it can be enforced only by tracking dependencies which seems to be very non-trivial and invasive.

I still do not completely give up with tracking dependencies approach, but decided first to try more simple solution - prefetching. It is already used for physical replication. Certainly in case of physical replication it is much simpler, because each WAL record contains list of accessed blocks.

In case of logical replication prefetching can be done either by prefetching access to replica identity index (usually primary key), either by executing replication command by some background worker
Certainly first case is much more easy. We just perform index lookup in prefetch worker and it loads accessed index and heap pages in shared buffer, so main apply worker does not need to read something from disk.
But it works well only for DELETE and HOT UPDATE operations.

In the second case we normally execute the LR command in background worker and then abort transaction. Certainly in this case we are doing the same work twice. But assumption is the same: parallel prefetch workers should load affected pages, speeding up work of the main apply worker.
